### PR TITLE
Miura/zero copy for shared memory

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,6 +12,7 @@
 
 int
 main() {
+/*
     // initialize socket & server instance
     UnixDomainSocketServer socket = UnixDomainSocketServer();
     DoorApiManager doorApiManager = DoorApiManager();
@@ -19,19 +20,12 @@ main() {
 
     // start server
     socket.run();
-
-/*
+*/
     std::string shmKey = "hoge";
     SharedMemory<Dpi, SharedPacketInformation> doorShm = SharedMemory<Dpi, SharedPacketInformation>(shmKey);
-    Dpi dpi = Dpi();
-    for (unsigned long i = 0; i < SharedPacketInformation::getSharedDataSize(); i++) {
-        dpi.data_[i]= 'a';
-    }
-
-    std::cout << "DoorWorker::run start writing" << std::endl;
-    doorShm.write(&dpi);
-    doorShm.removeSharedMemory();
-*/
+    Dpi* dpi = NULL;
+    doorShm.read(&dpi);
+    std::cout << dpi->data_ << std::endl;
 
     return 0;
 }


### PR DESCRIPTION
ここら辺の記事からおそらくできないことが判明。
shared memoryのオブジェクトを指すポインタをコピーする
http://dixq.net/forum/viewtopic.php?f=3&t=15677

http://blog.systemjp.net/entry/20120405/p2

